### PR TITLE
--arch support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .#*
 .*.swp
 .idea/
+.DS_Store

--- a/lambdabats/main.go
+++ b/lambdabats/main.go
@@ -38,7 +38,7 @@ var OutputFormat = flag.String("F", "pretty", "format the test results output; e
 var ExecutionStrategy = flag.String("s", "lambda", "execution strategy;\n  lambda - run most tests remote, some locally;\n  lambda_skip - run most tests remote, skip others;\n  lambda_emulator - run all tests against a local lambda simulator")
 var EnvCreds = flag.Bool("use-aws-environment-credentials", false, "by default we use hard-coded credentials which work for DoltHub developers; this uses credentials from the environment instead.")
 var TargetArch = flag.String("arch", "arm64", "target architecture for the lambda function; either amd64 or arm64")
-var SaveArtifacts = flag.Bool("save-artifacts", false, "Print the location of the test artifacts instead of deleting them after the test run")
+var BuildOnly = flag.Bool("build-only", false, "Print the location of the test artifacts and exit without running the tests.")
 
 var EnvVars []string
 
@@ -112,6 +112,11 @@ func main() {
 		PrintUsage()
 	}
 
+	if *TargetArch == "amd64" {
+		fmt.Println("Forcing --build-only because x86 is not supported")
+		*BuildOnly = true
+	}
+
 	fileArgs := flag.Args()
 	if len(fileArgs) == 0 {
 		fmt.Println("must supply tests to run")
@@ -146,9 +151,14 @@ func main() {
 		config = NewTestRunConfig()
 	}
 
-	testArtifacts, err := UploadTests(ctx, config.Uploader, doltSrcDir, *TargetArch, *SaveArtifacts)
+	testArtifacts, err := UploadTests(ctx, config.Uploader, doltSrcDir, *TargetArch, *BuildOnly)
 	if err != nil {
 		panic(err)
+	}
+
+	if *BuildOnly {
+		fmt.Println("Test artifacts saved. Exiting.")
+		os.Exit(0)
 	}
 
 	files, total, err := LoadTestFiles(fileArgs)

--- a/lambdabats/main.go
+++ b/lambdabats/main.go
@@ -37,6 +37,8 @@ var OutputResults = OutputBatsResults
 var OutputFormat = flag.String("F", "pretty", "format the test results output; either bats pretty format or tap")
 var ExecutionStrategy = flag.String("s", "lambda", "execution strategy;\n  lambda - run most tests remote, some locally;\n  lambda_skip - run most tests remote, skip others;\n  lambda_emulator - run all tests against a local lambda simulator")
 var EnvCreds = flag.Bool("use-aws-environment-credentials", false, "by default we use hard-coded credentials which work for DoltHub developers; this uses credentials from the environment instead.")
+var TargetArch = flag.String("arch", "arm64", "target architecture for the lambda function; either amd64 or arm64")
+var SaveArtifacts = flag.Bool("save-artifacts", false, "Print the location of the test artifacts instead of deleting them after the test run")
 
 var EnvVars []string
 
@@ -105,6 +107,10 @@ func main() {
 		fmt.Println("invalid execution strategy")
 		PrintUsage()
 	}
+	if *TargetArch != "arm64" && *TargetArch != "amd64" {
+		fmt.Println("invalid target architecture")
+		PrintUsage()
+	}
 
 	fileArgs := flag.Args()
 	if len(fileArgs) == 0 {
@@ -140,7 +146,7 @@ func main() {
 		config = NewTestRunConfig()
 	}
 
-	testArtifacts, err := UploadTests(ctx, config.Uploader, doltSrcDir)
+	testArtifacts, err := UploadTests(ctx, config.Uploader, doltSrcDir, *TargetArch, *SaveArtifacts)
 	if err != nil {
 		panic(err)
 	}

--- a/lambdabats/upload.go
+++ b/lambdabats/upload.go
@@ -42,7 +42,7 @@ import (
 // Download a supported C compiler targeting linux-arm64 so we can build a
 // statically compiled dolt binary. Return environment variables for
 // configuring CGO to compile with this compiler.
-func StageCompiler() ([]string, error) {
+func StageCompiler(targetArch string) ([]string, error) {
 	type location struct {
 		url string
 		sha string
@@ -74,7 +74,7 @@ func StageCompiler() ([]string, error) {
 	}
 
 	gnuArch := "x86_64"
-	if runtime.GOARCH == "arm64" {
+	if targetArch == "arm64" {
 		gnuArch = "aarch64"
 	}
 
@@ -138,7 +138,7 @@ func BuildTestsFile(doltSrcDir, arch string) (UploadArtifacts, error) {
 	doltBinFilePath := filepath.Join(binDir, "dolt")
 	compileEnv := append(os.Environ(), "GOOS=linux", "GOARCH="+arch)
 	err := RunWithSpinner("downloading toolchain...", func() error {
-		vars, err := StageCompiler()
+		vars, err := StageCompiler(arch)
 		if err != nil {
 			return fmt.Errorf("unable to stage compiler toolchain: %w", err)
 		}
@@ -398,7 +398,7 @@ func UploadTests(ctx context.Context, uploader Uploader, doltSrcDir, arch string
 	if err != nil {
 		return UploadLocations{}, err
 	}
-	
+
 	return ans, nil
 }
 


### PR DESCRIPTION
Had a situation where we needed an x86 build for a user. Also noticed that we always use the arm compiler even though we have the x86 compilers in the tool bundle, so tweaked that too.